### PR TITLE
Update node16 to node20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -5,7 +5,7 @@ branding:
   icon: 'check'
   color: 'gray-dark'
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'
 inputs:
   github-token:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pr-number-action",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "Replaces [#PR] with an actual PR number in a description body",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
When using, I'm getting node16 deprecation errors. 
> The following actions uses Node.js version which is deprecated and will be forced to run on node20: matyas-igor/pr-number-action@v1. For more info: https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/

Bumping to node20 to resolve errors
